### PR TITLE
feat: add docker compose script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/book
+.env*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,136 @@
+services:
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379
+    networks:
+      - amplica-gateway
+    volumes:
+      - redis_data:/data/redis
+
+  frequency:
+    image: dsnp/instant-seal-node-with-deployed-schemas:latest
+    # We need to specify the platform because it's the only image
+    # built by Frequency at the moment, and auto-pull won't work otherwise
+    platform: linux/amd64
+    # Uncomment SEALING_MODE and SEALING_INTERVAL if you want to use interval sealing.
+    # Other options you may want to add depending on your test scenario.
+    # environment:
+    #   - SEALING_MODE=interval
+    #   - SEALING_INTERVAL=3
+    #   - CREATE_EMPTY_BLOCKS=true
+    # The 'command' may contain additional CLI options to the Frequency node,
+    # such as:
+    # --state-pruning=archive
+    command: --offchain-worker=always --enable-offchain-indexing=true
+    ports:
+      - 9944:9944
+    networks:
+      - amplica-gateway
+    volumes:
+      - chainstorage:/data
+
+  kubo_ipfs:
+    image: ipfs/kubo:latest
+    ports:
+      - 4001:4001
+      - 5001:5001
+      - 8080:8080
+    networks:
+      - amplica-gateway
+    volumes:
+      - ipfs_data:/data/ipfs
+
+  content-publishing-service-api:
+    image: amplicalabs/content-publishing-service:latest
+    platform: linux/amd64
+    ports:
+      - 3001:3000
+    env_file:
+      - path: .env.common
+        required: true
+      - path: .env.content-publishing-service
+        required: false
+    environment:
+      - START_PROCESS=api
+    depends_on:
+      - redis
+      - frequency
+      - kubo_ipfs
+    networks:
+      - amplica-gateway
+
+  content-publishing-service-worker:
+    image: amplicalabs/content-publishing-service:latest
+    platform: linux/amd64
+    env_file:
+      - path: .env.common
+        required: true
+      - path: .env.content-publishing-service
+        required: false
+    environment:
+      - START_PROCESS=worker
+    depends_on:
+      - redis
+      - frequency
+      - kubo_ipfs
+    networks:
+      - amplica-gateway
+
+  graph-service:
+    image: amplicalabs/graph-service:latest
+    platform: linux/amd64
+    ports:
+      - 3002:3000
+    env_file:
+      - path: .env.common
+        required: true
+      - path: .env.graph-service
+        required: false
+    depends_on:
+      - redis
+      - frequency
+    networks:
+      - amplica-gateway
+
+  account-service-api:
+    image: amplicalabs/account-service:latest
+    platform: linux/amd64
+    ports:
+      - 3003:3000
+    command: api
+    env_file:
+      - path: .env.common
+        required: true
+      - path: .env.account-service
+        required: false
+    depends_on:
+      - redis
+      - frequency
+    networks:
+      - amplica-gateway
+
+  account-service-worker:
+    image: amplicalabs/account-service:latest
+    platform: linux/amd64
+    command: worker
+    env_file:
+      - path: .env.common
+        required: true
+      - path: .env.account-service
+        required: false
+    depends_on:
+      - redis
+      - frequency
+
+    networks:
+      - amplica-gateway
+
+volumes:
+  ipfs_data:
+  chainstorage:
+    external: false
+  redis_data:
+
+networks:
+  amplica-gateway:

--- a/environment/env.account-service.template
+++ b/environment/env.account-service.template
@@ -1,0 +1,38 @@
+# Copy this file to "<project_root>/.env.account-service", and then tweak values for local development
+# Values in this file will override the same-named environnent variables in `.env.common.docker` for the account-service
+
+# Base URL for provider webhook endpoints
+# PROVIDER_BASE_URL=https://some-provider/api/v1.0.0
+
+# An optional bearer token authentication to the provider webhook
+# PROVIDER_ACCESS_TOKEN=some-token
+
+# Number of failures allowing in the provider webhook before the service is marked down
+# WEBHOOK_FAILURE_THRESHOLD=3
+
+# Number of seconds between provider webhook retry attempts when failing
+# WEBHOOK_RETRY_INTERVAL_SECONDS=10
+
+# Number of `/health` endpoint failures allowed before marking the provider webhook service down
+# HEALTH_CHECK_MAX_RETRIES=4
+
+# Number of seconds to retry provider webhook `/health` endpoint when failing
+# HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS=10
+
+# Minimum number of consecutive successful calls to the provider webhook
+# `/health` endpoint before it is marked up again
+# HEALTH_CHECK_SUCCESS_THRESHOLD=10
+
+# Maximum amount of provider capacity this app is allowed to use (per epoch)
+#     type: 'percentage' | 'amount'
+#     value: number (may be percentage, ie '80', or absolute amount of capacity)
+# CAPACITY_LIMIT='{"type":"percentage", "value":80}'
+
+# URL for the Sign-In With Frequency UI
+# SIWF_URL=https://amplicalabs.github.io/siwf/ui
+
+# Domain for the Sign-in with Frequency login payload
+# SIWF_DOMAIN=localhost
+
+# Enable debug mode for development
+# DEBUG=true

--- a/environment/env.common.template
+++ b/environment/env.common.template
@@ -1,0 +1,49 @@
+# Copy this file to ".env.dev" and ".env.docker.dev", and then tweak values for local development
+
+# Blockchain node address
+FREQUENCY_URL=ws://0.0.0.0:9944
+
+# Specifies the provider ID
+PROVIDER_ID=1
+
+# Base URL for provider webhook endpoints
+PROVIDER_BASE_URL=https://some-provider/api/v1.0.0
+
+# Redis URL
+REDIS_URL=redis://0.0.0.0:6379
+
+# An optional bearer token authentication to the provider webhook
+PROVIDER_ACCESS_TOKEN=some-token
+
+# Seed phrase for provider MSA control key
+PROVIDER_ACCOUNT_SEED_PHRASE='come finish flower cinnamon blame year glad tank domain hunt release fatigue'
+
+# Number of failures allowing in the provider webhook before the service is marked down
+WEBHOOK_FAILURE_THRESHOLD=3
+
+# Number of seconds between provider webhook retry attempts when failing
+WEBHOOK_RETRY_INTERVAL_SECONDS=10
+
+# Number of `/health` endpoint failures allowed before marking the provider webhook service down
+HEALTH_CHECK_MAX_RETRIES=4
+
+# Number of seconds to retry provider webhook `/health` endpoint when failing
+HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS=10
+
+# Minimum number of consecutive successful calls to the provider webhook
+# `/health` endpoint before it is marked up again
+HEALTH_CHECK_SUCCESS_THRESHOLD=10
+
+# Maximum amount of provider capacity this app is allowed to use (per epoch)
+#     type: 'percentage' | 'amount'
+#     value: number (may be percentage, ie '80', or absolute amount of capacity)
+CAPACITY_LIMIT='{"type":"percentage", "value":80}'
+
+# URL for the Sign-In With Frequency UI
+SIWF_URL=https://amplicalabs.github.io/siwf/ui
+
+# Domain for the Sign-in with Frequency login payload
+SIWF_DOMAIN=localhost
+
+# Enable debug mode for development
+DEBUG=false

--- a/environment/env.content-publishing-service.template
+++ b/environment/env.content-publishing-service.template
@@ -1,0 +1,42 @@
+# Copy this file to "<project_root>/.env.content-publishing-service", and then tweak values for local development
+# Values in this file will override the same-named environnent variables in `.env.common.docker` for the content-publishing-service
+
+# URL to IPFS endpoint
+# IPFS_ENDPOINT="https://ipfs.infura.io:5001"
+IPFS_ENDPOINT="http://kubo_ipfs:5001"
+
+# If using Infura, put Project ID here, or leave blank for Kubo RPC
+# IPFS_BASIC_AUTH_USER=
+
+# If using Infura, put auth token here, or leave blank for Kubo RPC
+# IPFS_BASIC_AUTH_SECRET=
+
+# IPFS gateway URL. '[CID]' is a token that will be replaced with an actual content ID
+# IPFS_GATEWAY_URL="https://ipfs.io/ipfs/[CID]"
+IPFS_GATEWAY_URL="http://kubo_ipfs:8080/ipfs/[CID]"
+
+CAPACITY_LIMIT='{"type":"percentage", "value":80}'
+
+# Environment for mapping announcement type to schema ID (use 'dev' for e2e tests)
+# Possible values: dev, rococo, testnet, mainnet
+CHAIN_ENVIRONMENT=dev
+
+# Max file size allowed for asset upload
+FILE_UPLOAD_MAX_SIZE_IN_BYTES=2000000000
+
+# Number of seconds to keep completed asset entrie in the cache
+# before expiring them
+ASSET_EXPIRATION_INTERVAL_SECONDS=300
+
+# Number of seconds between content publishing batches. This is so that
+# the service waits a reasonable amount of time for additional content to publishing
+# before submitting a batch--it represents a trade-off between maximum batch fullness
+# and minimal wait time for published content.
+BATCH_INTERVAL_SECONDS=12
+
+# Maximum number of items that can be submitted in a single batch
+BATCH_MAX_COUNT=1000
+
+# Base delay in seconds used for exponential backoff while waiting for
+# uploaded assets to be verified available before publishing a content notice.
+ASSET_UPLOAD_VERIFICATION_DELAY_SECONDS=5

--- a/environment/env.content-watcher-service.template
+++ b/environment/env.content-watcher-service.template
@@ -1,0 +1,33 @@
+# Copy this file to "<project_root>/.env.content-watcher-service", and then tweak values for local development
+# Values in this file will override the same-named environnent variables in `.env.common.docker` for the content-watcher-service
+
+# URL to IPFS endpoint
+# IPFS_ENDPOINT="https://ipfs.infura.io:5001"
+IPFS_ENDPOINT="http://kubo_ipfs:5001"
+
+# If using Infura, put Project ID here, or leave blank for Kubo RPC
+# IPFS_BASIC_AUTH_USER=
+
+# If using Infura, put auth token here, or leave blank for Kubo RPC
+IPFS_BASIC_AUTH_SECRET=
+
+# IPFS gateway URL. '[CID]' is a token that will be replaced with an actual content ID
+# IPFS_GATEWAY_URL="https://ipfs.io/ipfs/[CID]"
+IPFS_GATEWAY_URL="http://kubo_ipfs:8080/ipfs/[CID]"
+
+# Block number from which the service will start scanning the chain
+STARTING_BLOCK=1
+
+# How many minutes to delay between successive scans of the chain
+# for new accounts (after end of chain is reached)
+BLOCKCHAIN_SCAN_INTERVAL_MINUTES=1
+
+# Max number of jobs allowed on the queue before
+# blockchain scan will be paused to allow queue to drain
+QUEUE_HIGH_WATER=1000
+
+# Number of retry attempts if a registered webhook call fails
+WEBHOOK_FAILURE_THRESHOLD=4
+
+# Number of seconds between webhook retry attempts when failing
+WEBHOOK_RETRY_INTERVAL_SECONDS=10

--- a/environment/env.graph-service.template
+++ b/environment/env.graph-service.template
@@ -1,0 +1,85 @@
+# Copy this file to "<project_root>/.env.graph-service", and then tweak values for local development
+# Values in this file will override the same-named environnent variables in `.env.common.docker` for the graph-service
+
+# Max number of jobs allowed on the 'graphUpdateQueue' before
+# blockchain scan will be paused to allow queue to drain
+QUEUE_HIGH_WATER=1000
+
+# Number of seconds to retain pending graph updates in the Redis cache to avoid redundant fetches from the chain
+DEBOUNCE_SECONDS=10
+
+# Maximum amount of provider capacity this app is allowed to use (per epoch)
+#     type: 'percentage' | 'amount'
+#     value: number (may be percentage, ie '80', or absolute amount of capacity)
+CAPACITY_LIMIT='{"type":"percentage", "value":80}'
+
+# Graph environment type. This can be 'Dev' or 'Rococo', 'TestnetPaseo', or 'Mainnet'.
+GRAPH_ENVIRONMENT_TYPE=Dev
+
+# [NOTE]: The following config is only used for Dev environments.
+# Add the graph environment config in JSON format only used for Dev environments.
+# Be careful to escape any inner quotes as this is in a .env file.
+GRAPH_ENVIRONMENT_DEV_CONFIG='{
+	"sdkMaxStaleFriendshipDays": 100,
+	"maxPageId": 100,
+	"dsnpVersions": [
+	  "1.0"
+	],
+	"maxGraphPageSizeBytes": 100,
+	"maxKeyPageSizeBytes": 100,
+	"schemaMap": {
+	  "1": {
+		"dsnpVersion": "1.0",
+		"connectionType": "follow",
+		"privacyType": "public"
+	  },
+	  "2": {
+		"dsnpVersion": "1.0",
+		"connectionType": "follow",
+		"privacyType": "private"
+	  },
+	  "3": {
+		"dsnpVersion": "1.0",
+		"connectionType": "friendship",
+		"privacyType": "private"
+	  }
+	},
+   "graphPublicKeySchemaId": 4
+  }
+  '
+PROVIDER_ACCOUNT_SEED_PHRASE="//Ferdie"
+
+# Whether to instantiate/activate reconnection-service features
+RECONNECTION_SERVICE_REQUIRED=false
+
+### The following are only applicable if RECONNECTION_SERVICE_REQUIRED is 'true'
+
+# Base URL for provider webhook endpoints
+# PROVIDER_BASE_URL=https://some-provider/api/v1.0.0
+
+# An optional bearer token authentication to the provider webhook
+# PROVIDER_ACCESS_TOKEN=some-token
+
+# Number of connection/page to request when requesting provider connections from webhook
+C# ONNECTIONS_PER_PROVIDER_RESPONSE_PAGE=100
+
+
+# How many minutes to delay between successive scans of the chain
+# for new accounts (after end of chain is reached)
+# BLOCKCHAIN_SCAN_INTERVAL_MINUTES=1
+
+# Number of failures allowing in the provider webhook before the service is marked down
+# WEBHOOK_FAILURE_THRESHOLD=3
+
+# Minimum number of consecutive successful calls to the provider webhook
+# `/health` endpoint before it is marked up again
+# HEALTH_CHECK_SUCCESS_THRESHOLD=10
+
+# Number of seconds between provider webhook retry attempts when failing
+# WEBHOOK_RETRY_INTERVAL_SECONDS=10
+
+# Number of seconds to retry provider webhook `/health` endpoint when failing
+# HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS=10
+
+# Number of `/health` endpoint failures allowed before marking the provider webhook service down
+# HEALTH_CHECK_MAX_RETRIES=4


### PR DESCRIPTION
# Description
This PR adds a basic `docker compose` script to bring up all Gateway backend services _excluding_ the Gateway itself (this is for the scenario where the developer has their own Gateway-compatible app, possibly not based on our `social-app-template` repo)

Closes #156 
