### PR TITLE
fix: consolidate release CI pipeline to a common workflow

### DIFF
--- a/.github/workflows/account-release.yml
+++ b/.github/workflows/account-release.yml
@@ -4,12 +4,12 @@ concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true
 on:
-  push:
-    tags:
-      - "account-v[0-9]+.[0-9]+.[0-9]+" # ex. v1.0.0
-      - "account-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v1.1.0-rc1
-      - "account-v0.0.1" # used for testing only
-      - "account-v0.0.1-rc[0-9]+" # used for testing only
+  # push:
+  #   tags:
+  #     - "account-v[0-9]+.[0-9]+.[0-9]+" # ex. v1.0.0
+  #     - "account-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v1.1.0-rc1
+  #     - "account-v0.0.1" # used for testing only
+  #     - "account-v0.0.1-rc[0-9]+" # used for testing only
   workflow_dispatch:
     inputs:
       release-version:

--- a/.github/workflows/content-publishing-release.yml
+++ b/.github/workflows/content-publishing-release.yml
@@ -4,12 +4,12 @@ concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true
 on:
-  push:
-    tags:
-      - "content-publishing-v[0-9]+.[0-9]+.[0-9]+" # ex. v1.0.0
-      - "content-publishing-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v1.1.0-rc1
-      - "content-publishing-v0.0.1" # used for testing only
-      - "content-publishing-v0.0.1-rc[0-9]+" # used for testing only
+  # push:
+  #   tags:
+  #     - "content-publishing-v[0-9]+.[0-9]+.[0-9]+" # ex. v1.0.0
+  #     - "content-publishing-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v1.1.0-rc1
+  #     - "content-publishing-v0.0.1" # used for testing only
+  #     - "content-publishing-v0.0.1-rc[0-9]+" # used for testing only
   workflow_dispatch:
     inputs:
       release-version:

--- a/.github/workflows/content-watcher-release.yml
+++ b/.github/workflows/content-watcher-release.yml
@@ -4,12 +4,12 @@ concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true
 on:
-  push:
-    tags:
-      - "content-watcher-v[0-9]+.[0-9]+.[0-9]+" # ex. v1.0.0
-      - "content-watcher-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v1.1.0-rc1
-      - "content-watcher-v0.0.1" # used for testing only
-      - "content-watcher-v0.0.1-rc[0-9]+" # used for testing only
+  # push:
+  #   tags:
+  #     - "content-watcher-v[0-9]+.[0-9]+.[0-9]+" # ex. v1.0.0
+  #     - "content-watcher-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v1.1.0-rc1
+  #     - "content-watcher-v0.0.1" # used for testing only
+  #     - "content-watcher-v0.0.1-rc[0-9]+" # used for testing only
   workflow_dispatch:
     inputs:
       release-version:

--- a/.github/workflows/graph-release.yml
+++ b/.github/workflows/graph-release.yml
@@ -4,12 +4,12 @@ concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true
 on:
-  push:
-    tags:
-      - "graph-v[0-9]+.[0-9]+.[0-9]+" # ex. v1.0.0
-      - "graph-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v1.1.0-rc1
-      - "graph-v0.0.1" # used for testing only
-      - "graph-v0.0.1-rc[0-9]+" # used for testing only
+  # push:
+  #   tags:
+  #     - "graph-v[0-9]+.[0-9]+.[0-9]+" # ex. v1.0.0
+  #     - "graph-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+" # ex. v1.1.0-rc1
+  #     - "graph-v0.0.1" # used for testing only
+  #     - "graph-v0.0.1-rc[0-9]+" # used for testing only
   workflow_dispatch:
     inputs:
       release-version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: "Release"
+run-name: "Cut Release ${{ github.event.release.tag_name || github.event.inputs.release-tag}}"
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "Release tag ([servicename-]v#.#.#[-rc#])"
+        required: true
+
+env:
+  FULL_TAG: ${{ github.event.release.tag_name || github.event.inputs.release-tag}}
+  DOCKER_HUB_PROFILE: amplicalabs
+  ALL_SERVICES: '["account", "content-publishing", "content-watcher", "graph"]'
+
+jobs:
+  set_variables:
+    runs-on: ubuntu-latest
+    outputs:
+      full_tag: ${{ steps.set_version_tag.outputs.TAG }}
+      version_tag: ${{ steps.set_version_tag.outputs.VERSION }}
+      service_name: ${{ steps.set_version_tag.outputs.SERVICE }}
+      service_matrix: ${{ steps.set_version_tag.outputs.SERVICE_MATRIX }}
+      valid_semver: ${{ steps.set_version_tag.outputs.valid }}
+      test_run: ${{ steps.set_version_tag.outputs.test_run }}
+    steps:
+      - name: Extract and Validate Version Tag
+        id: set_version_tag
+        run: |
+          valid=false
+          test_run=false
+          ENTIRE_TAG_RE="^(([[:alpha:]]+)-)?(.*)$"
+          VERSION_TAG_RE="^v[\.]?([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alpha:][:digit:]\.]+)*)$"
+          TAG="${{ github.event.release.tag_name }}"
+          echo "Running with tag: ${TAG}"
+          if [[ "$TAG" =~ ${ENTIRE_TAG_RE} ]] ; then
+            SERVICE=${BASH_REMATCH[2]}
+            VERSION_TAG=${BASH_REMATCH[3]}
+            if [[ ${VERSION_TAG} =~ ${VERSION_TAG_RE} ]] ; then
+              version=${BASH_REMATCH[1]}
+              valid=true
+              if [[ ${version} = "0.0.1" ]] ; then
+                test_run=true
+              fi
+
+              if [[ -z "${SERVICE}" ]] ; then
+                SERVICE_MATRIX="${ALL_SERVICES}"
+              else
+                SERVICE_MATRIX="[\"${SERVICE}\"]"
+              fi
+
+              echo "::set-output name=TAG::${TAG}"
+              echo "::set-output name=VERSION::${VERSION_TAG}"
+              echo "::set-output name=SERVICE::${SERVICE}"
+              echo "::set-output name=SERVICE_MATRIX::${SERVICE_MATRIX}"
+              echo "::set-output name=valid::${valid}"
+              echo "::set-output name=test_run::${test_run}"
+            fi
+          fi
+          if [[ "${valid}" = false ]]
+          then
+            echo "::set-output name=SERVICE_MATRIX::[]"
+            echo "::set-output name=valid::${valid}"
+            echo "Release tag '${TAG}' is not valid for deployment."
+            echo "ERROR: Entered tag ${TAG} is not valid."
+            echo "Please use [service-]v#.#.#[-rc#] format."
+            exit 1
+          fi
+
+  checkout:
+    name: Check Out Repo
+    runs-on: ubuntu-latest
+    needs: set_variables
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.set_variables.outputs.full_tag }}
+
+  build-and-publish-container-image:
+    name: Build and publish container image
+    needs: [checkout, set_variables]
+    runs-on: ubuntu-latest
+    if: needs.set_variables.outputs.valid_semver == 'true'
+    strategy:
+      matrix:
+        service: ${{ fromJson(needs.set_variables.outputs.service_matrix) }}
+    steps:
+      - name: Deploy Service
+        run: |
+          echo "Deploying service: ${{ matrix.service }}"
+      - name: Set up tags for cp image
+        id: cp-tags
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            latest=auto
+          images: |
+            ${{env.DOCKER_HUB_PROFILE}}/${{matrix.service}}-service
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.set_variables.outputs.version_tag }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: |
+            linux/amd64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
+          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
+      - name: Build and Push account-service-service Image
+        uses: docker/build-push-action@v5
+        with:
+          context: services/${{ matrix.service }}
+          platforms: linux/amd64
+          push: ${{ needs.set_variables.outputs.test_run != 'true'}}
+          file: services/account/Dockerfile
+          tags: ${{ steps.cp-tags.outputs.tags }}


### PR DESCRIPTION
This PR refactors the release CI pipeline as follows:
- Create `release.yaml` workflow as a common release CI pipeline for all services
    - New pipeline uses a matrix approach to release one or all services based on tag prefix
    - New pipeline triggers on a "release[publish]" event instead of "push: tag"
    - Old individual service release pipelines are set to manual-only for now (will remove in a future PR)