### PR TITLE
fix: can't exclude repo checkout from matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,25 +71,19 @@ jobs:
             exit 1
           fi
 
-  checkout:
-    name: Check Out Repo
-    runs-on: ubuntu-latest
-    needs: set_variables
-    steps:
-      - name: Check Out Repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.set_variables.outputs.full_tag }}
-
   build-and-publish-container-image:
     name: Build and publish container image
-    needs: [checkout, set_variables]
+    needs: set_variables
     runs-on: ubuntu-latest
     if: needs.set_variables.outputs.valid_semver == 'true'
     strategy:
       matrix:
         service: ${{ fromJson(needs.set_variables.outputs.service_matrix) }}
     steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.set_variables.outputs.full_tag }}
       - name: Deploy Service
         run: |
           echo "Deploying service: ${{ matrix.service }}"


### PR DESCRIPTION
Tried to factor out the repo checkout to its own job so that it didn't have to be run multiple times, but that didn't work.