### PR TITLE
fix: use createFromUri instead of addFromUri for keys

### DIFF
--- a/services/account/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/account/libs/common/src/blockchain/blockchain.service.ts
@@ -23,8 +23,8 @@ import { decodeAddress } from '@polkadot/util-crypto';
 import { KeysRequest } from '#lib/types/dtos/keys.request.dto';
 import { PublishHandleRequest } from '#lib/types/dtos/handles.request.dto';
 import { TransactionData } from '#lib/types/dtos/transaction.request.dto';
-import { Extrinsic } from './extrinsic';
 import { HandleResponseDTO } from '#lib/types/dtos/accounts.response.dto';
+import { Extrinsic } from './extrinsic';
 
 export type Sr25519Signature = { Sr25519: HexString };
 interface SIWFTxnValues {
@@ -252,8 +252,8 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
         base_handle: handle.base_handle.toString(),
         canonical_base: handle.canonical_base.toString(),
         suffix: handle.suffix.toNumber(),
+      };
     }
-  }
 
     this.logger.error(`getHandleForMsa: No handle found for msaId: ${msaId}`);
     return null;

--- a/services/account/libs/common/src/blockchain/create-keys.ts
+++ b/services/account/libs/common/src/blockchain/create-keys.ts
@@ -1,15 +1,8 @@
 import { Keyring } from '@polkadot/api';
 import { KeyringPair } from '@polkadot/keyring/types';
 
-// eslint-disable-next-line import/no-mutable-exports
-export let keyring: Keyring;
+const keyring: Keyring = new Keyring({ type: 'sr25519' });
 
 export function createKeys(uri: string): KeyringPair {
-  if (!keyring) {
-    keyring = new Keyring({ type: 'sr25519' });
-  }
-
-  const keys = keyring.createFromUri(uri);
-
-  return keys;
+  return keyring.createFromUri(uri);
 }

--- a/services/account/libs/common/src/blockchain/create-keys.ts
+++ b/services/account/libs/common/src/blockchain/create-keys.ts
@@ -9,7 +9,7 @@ export function createKeys(uri: string): KeyringPair {
     keyring = new Keyring({ type: 'sr25519' });
   }
 
-  const keys = keyring.addFromUri(uri);
+  const keys = keyring.createFromUri(uri);
 
   return keys;
 }

--- a/services/content-publishing/libs/common/src/blockchain/create-keys.ts
+++ b/services/content-publishing/libs/common/src/blockchain/create-keys.ts
@@ -1,14 +1,8 @@
 import { Keyring } from '@polkadot/api';
 import { KeyringPair } from '@polkadot/keyring/types';
 
-export let keyring: Keyring;
+const keyring: Keyring = new Keyring({ type: 'sr25519' });
 
 export function createKeys(uri: string): KeyringPair {
-  if (!keyring) {
-    keyring = new Keyring({ type: 'sr25519' });
-  }
-
-  const keys = keyring.createFromUri(uri);
-
-  return keys;
+  return keyring.createFromUri(uri);
 }

--- a/services/content-publishing/libs/common/src/blockchain/create-keys.ts
+++ b/services/content-publishing/libs/common/src/blockchain/create-keys.ts
@@ -8,7 +8,7 @@ export function createKeys(uri: string): KeyringPair {
     keyring = new Keyring({ type: 'sr25519' });
   }
 
-  const keys = keyring.addFromUri(uri);
+  const keys = keyring.createFromUri(uri);
 
   return keys;
 }

--- a/services/content-publishing/scripts/local-init.cjs
+++ b/services/content-publishing/scripts/local-init.cjs
@@ -1,6 +1,6 @@
-const { options } = require("@frequency-chain/api-augment");
-const { WsProvider, ApiPromise, Keyring } = require("@polkadot/api");
-const { deploy } = require("@dsnp/frequency-schemas/cli/deploy");
+const { options } = require('@frequency-chain/api-augment');
+const { WsProvider, ApiPromise, Keyring } = require('@polkadot/api');
+const { deploy } = require('@dsnp/frequency-schemas/cli/deploy');
 
 // Given a list of events, a section and a method,
 // returns the first event with matching section and method.
@@ -10,82 +10,88 @@ const eventWithSectionAndMethod = (events, section, method) => {
 };
 
 const main = async () => {
-  console.log("A quick script that will setup a clean localhost instance of Frequency for DSNP ");
+  console.log('A quick script that will setup a clean localhost instance of Frequency for DSNP ');
 
-  const providerUri = "ws://127.0.0.1:9944";
+  const providerUri = 'ws://127.0.0.1:9944';
   const provider = new WsProvider(providerUri);
   const api = await ApiPromise.create({ provider, throwOnConnect: true, ...options });
-  const keys = new Keyring().addFromUri("//Alice", {}, "sr25519");
+  const keys = new Keyring().createFromUri('//Alice', {}, 'sr25519');
 
   // Create alice msa
   await new Promise((resolve, reject) => {
-    console.log("Creating an MSA...");
-    api.tx.msa.create()
-      .signAndSend(keys, {}, ({ status, events, dispatchError }) => {
-        if (dispatchError) {
-          console.error("ERROR: ", dispatchError.toHuman());
+    console.log('Creating an MSA...');
+    api.tx.msa.create().signAndSend(keys, {}, ({ status, events, dispatchError }) => {
+      if (dispatchError) {
+        console.error('ERROR: ', dispatchError.toHuman());
+        reject();
+      } else if (status.isInBlock || status.isFinalized) {
+        const evt = eventWithSectionAndMethod(events, 'msa', 'MsaCreated');
+        if (evt) {
+          const id = evt?.data[0];
+          console.log('SUCCESS: MSA Created:' + id);
+          resolve();
+        } else {
+          console.error(
+            'ERROR: Expected event not found',
+            events.map((x) => x.toHuman()),
+          );
           reject();
-        } else if (status.isInBlock || status.isFinalized) {
-          const evt = eventWithSectionAndMethod(events, "msa", "MsaCreated");
-          if (evt) {
-            const id = evt?.data[0];
-            console.log("SUCCESS: MSA Created:" + id);
-            resolve();
-          } else {
-            console.error("ERROR: Expected event not found", events.map(x => x.toHuman()));
-            reject();
-          }
         }
-      });
+      }
+    });
   });
 
   // Create alice provider
   await new Promise((resolve, reject) => {
-    console.log("Creating an Provider...");
-    api.tx.msa.createProvider("alice")
-      .signAndSend(keys, {}, ({ status, events, dispatchError }) => {
-        if (dispatchError) {
-          console.error("ERROR: ", dispatchError.toHuman());
+    console.log('Creating an Provider...');
+    api.tx.msa.createProvider('alice').signAndSend(keys, {}, ({ status, events, dispatchError }) => {
+      if (dispatchError) {
+        console.error('ERROR: ', dispatchError.toHuman());
+        reject();
+      } else if (status.isInBlock || status.isFinalized) {
+        const evt = eventWithSectionAndMethod(events, 'msa', 'ProviderCreated');
+        if (evt) {
+          const id = evt?.data[0];
+          console.log('SUCCESS: Provider Created:' + id);
+          resolve();
+        } else {
+          console.error(
+            'ERROR: Expected event not found',
+            events.map((x) => x.toHuman()),
+          );
           reject();
-        } else if (status.isInBlock || status.isFinalized) {
-          const evt = eventWithSectionAndMethod(events, "msa", "ProviderCreated");
-          if (evt) {
-            const id = evt?.data[0];
-            console.log("SUCCESS: Provider Created:" + id);
-            resolve();
-          } else {
-            console.error("ERROR: Expected event not found", events.map(x => x.toHuman()));
-            reject();
-          }
         }
-      });
+      }
+    });
   });
 
   // Alice provider get Capacity
   await new Promise((resolve, reject) => {
-    console.log("Staking for Capacity...");
-    api.tx.capacity.stake("1", 500_000 * Math.pow(8, 10))
-      .signAndSend(keys, {}, ({ status, events, dispatchError }) => {
-        if (dispatchError) {
-          console.error("ERROR: ", dispatchError.toHuman());
+    console.log('Staking for Capacity...');
+    api.tx.capacity.stake('1', 500_000 * Math.pow(8, 10)).signAndSend(keys, {}, ({ status, events, dispatchError }) => {
+      if (dispatchError) {
+        console.error('ERROR: ', dispatchError.toHuman());
+        reject();
+      } else if (status.isInBlock || status.isFinalized) {
+        const evt = eventWithSectionAndMethod(events, 'capacity', 'Staked');
+        if (evt) {
+          console.log('SUCCESS: Provider Staked:', evt.data.toHuman());
+          resolve();
+        } else {
+          console.error(
+            'ERROR: Expected event not found',
+            events.map((x) => x.toHuman()),
+          );
           reject();
-        } else if (status.isInBlock || status.isFinalized) {
-          const evt = eventWithSectionAndMethod(events, "capacity", "Staked");
-          if (evt) {
-            console.log("SUCCESS: Provider Staked:", evt.data.toHuman());
-            resolve();
-          } else {
-            console.error("ERROR: Expected event not found", events.map(x => x.toHuman()));
-            reject();
-          }
         }
-      });
+      }
+    });
   });
 
   // Deploy Schemas
   await deploy();
 
-  console.log("Setup Complete!");
-}
+  console.log('Setup Complete!');
+};
 
 main().catch(console.error).finally(process.exit);

--- a/services/content-watcher/libs/common/src/blockchain/create-keys.ts
+++ b/services/content-watcher/libs/common/src/blockchain/create-keys.ts
@@ -1,14 +1,8 @@
 import { Keyring } from '@polkadot/api';
 import { KeyringPair } from '@polkadot/keyring/types';
 
-export let keyring: Keyring;
+const keyring: Keyring = new Keyring({ type: 'sr25519' });
 
 export function createKeys(uri: string): KeyringPair {
-  if (!keyring) {
-    keyring = new Keyring({ type: 'sr25519' });
-  }
-
-  const keys = keyring.createFromUri(uri);
-
-  return keys;
+  return keyring.createFromUri(uri);
 }

--- a/services/content-watcher/libs/common/src/blockchain/create-keys.ts
+++ b/services/content-watcher/libs/common/src/blockchain/create-keys.ts
@@ -8,7 +8,7 @@ export function createKeys(uri: string): KeyringPair {
     keyring = new Keyring({ type: 'sr25519' });
   }
 
-  const keys = keyring.addFromUri(uri);
+  const keys = keyring.createFromUri(uri);
 
   return keys;
 }

--- a/services/content-watcher/scripts/chain-setup/local-chain-setup.cjs
+++ b/services/content-watcher/scripts/chain-setup/local-chain-setup.cjs
@@ -15,7 +15,7 @@ const main = async () => {
   const providerUri = 'ws://127.0.0.1:9944';
   const provider = new WsProvider(providerUri);
   const api = await ApiPromise.create({ provider, throwOnConnect: true, ...options });
-  const keys = new Keyring().addFromUri('//Alice', {}, 'sr25519');
+  const keys = new Keyring().createFromUri('//Alice', {}, 'sr25519');
 
   // Create alice msa
   await new Promise((resolve, reject) => {

--- a/services/graph/libs/common/src/blockchain/create-keys.ts
+++ b/services/graph/libs/common/src/blockchain/create-keys.ts
@@ -1,14 +1,8 @@
 import { Keyring } from '@polkadot/api';
 import { KeyringPair } from '@polkadot/keyring/types';
 
-export let keyring: Keyring;
+const keyring: Keyring = new Keyring({ type: 'sr25519' });
 
 export function createKeys(uri: string): KeyringPair {
-  if (!keyring) {
-    keyring = new Keyring({ type: 'sr25519' });
-  }
-
-  const keys = keyring.createFromUri(uri);
-
-  return keys;
+  return keyring.createFromUri(uri);
 }

--- a/services/graph/libs/common/src/blockchain/create-keys.ts
+++ b/services/graph/libs/common/src/blockchain/create-keys.ts
@@ -8,7 +8,7 @@ export function createKeys(uri: string): KeyringPair {
     keyring = new Keyring({ type: 'sr25519' });
   }
 
-  const keys = keyring.addFromUri(uri);
+  const keys = keyring.createFromUri(uri);
 
   return keys;
 }


### PR DESCRIPTION
This PR changes our usage of `keyring.addFromUri()` to `keyring.createFromUri()` so that keypairs will not be saved in a long-lived variable.

Note, this is only a minor improvement to security for the following reasons:
1. We do not have control over JS garbage collection, so not way to guarantee that the generated keypair is eliminated from memory at any given point in time
2. The seed phrase used to generate the keypair is currently injected to the application as an environment variable, so anyone with enough access to view the process could also see the environment

Closes #187 