### PR TITLE
DockerHub username switch `amplicalabs` -> `projectlibertylabs`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   FULL_TAG: ${{ github.event.release.tag_name || github.event.inputs.release-tag}}
-  DOCKER_HUB_PROFILE: amplicalabs
+  DOCKER_HUB_PROFILE: projectlibertylabs
   ALL_SERVICES: '["account", "content-publishing", "content-watcher", "graph"]'
 
 jobs:
@@ -107,8 +107,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{secrets.DOCKERHUB_USERNAME_FC}}
-          password: ${{secrets.DOCKERHUB_TOKEN_FC}}
+          username: ${{secrets.DOCKERHUB_USERNAME}}
+          password: ${{secrets.DOCKERHUB_TOKEN}}
       - name: Build and Push account-service-service Image
         uses: docker/build-push-action@v5
         with:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       - ipfs_data:/data/ipfs
 
   content-publishing-service-api:
-    image: amplicalabs/content-publishing-service:latest
+    image: projectlibertylabs/content-publishing-service:latest
     platform: linux/amd64
     ports:
       - 3001:3000
@@ -61,7 +61,7 @@ services:
       - amplica-gateway
 
   content-publishing-service-worker:
-    image: amplicalabs/content-publishing-service:latest
+    image: projectlibertylabs/content-publishing-service:latest
     platform: linux/amd64
     env_file:
       - path: .env.common
@@ -78,7 +78,7 @@ services:
       - amplica-gateway
 
   graph-service:
-    image: amplicalabs/graph-service:latest
+    image: projectlibertylabs/graph-service:latest
     platform: linux/amd64
     ports:
       - 3002:3000
@@ -94,7 +94,7 @@ services:
       - amplica-gateway
 
   account-service-api:
-    image: amplicalabs/account-service:latest
+    image: projectlibertylabs/account-service:latest
     platform: linux/amd64
     ports:
       - 3003:3000
@@ -111,7 +111,7 @@ services:
       - amplica-gateway
 
   account-service-worker:
-    image: amplicalabs/account-service:latest
+    image: projectlibertylabs/account-service:latest
     platform: linux/amd64
     command: worker
     env_file:

--- a/services/content-watcher/INSTALLING.md
+++ b/services/content-watcher/INSTALLING.md
@@ -9,9 +9,9 @@ The application requires a Redis server that is configured with `Append-only fil
 
 ### Standalone (complete) image
 
-The standalone container image is meant to be a complete solution for a provider. It contains a single instance of the main application, plus a pre-configured Redis server. Simply download the latest [container image](https://hub.docker.com/r/amplicalabs/content-watcher-service/) and deploy using your favorite container management system.
+The standalone container image is meant to be a complete solution for a provider. It contains a single instance of the main application, plus a pre-configured Redis server. Simply download the latest [container image](https://hub.docker.com/r/projectlibertylabs/content-watcher-service/) and deploy using your favorite container management system.
 ```
-    docker pull amplicalabs/content-watcher-service:standalone-latest
+    docker pull projectlibertylabs/content-watcher-service:standalone-latest
 ```
 
 The internal Redis server included in the complete image is already configured for persistence; it is simply necessary to configure your container pod to map the directory `/var/lib/redis` to a persistent storage volume.
@@ -22,9 +22,9 @@ Follow the instructions below for [configuration](#configuration), with the exce
 
 ### App-only image
 
-The app-only image is meant to be used for providers who would rather utilize a Redis instance in their own (or their cloud infrastructure provider's) external Redis instance or service. To download the latest [container image](https://hub.docker.com/r/amplicalabs/content-watcher-service/), simply:
+The app-only image is meant to be used for providers who would rather utilize a Redis instance in their own (or their cloud infrastructure provider's) external Redis instance or service. To download the latest [container image](https://hub.docker.com/r/projectlibertylabs/content-watcher-service/), simply:
 ```
-    docker pull amplicalabs/content-watcher-service:apponly-latest
+    docker pull projectlibertylabs/content-watcher-service:apponly-latest
 ```
 In this case, you need to ensure that the following settings are configured in your Redis instance:
 ```

--- a/services/content-watcher/docker-compose.yaml
+++ b/services/content-watcher/docker-compose.yaml
@@ -54,7 +54,7 @@ services:
       - ipfs_data:/data/ipfs
 
   content-publishing-service-api:
-    image: amplicalabs/content-publishing-service:latest
+    image: projectlibertylabs/content-publishing-service:latest
     # For now, this is the only platform image published.
     platform: linux/amd64
     ports:
@@ -72,7 +72,7 @@ services:
       - content-watcher-service
 
   content-publishing-service-worker:
-    image: amplicalabs/content-publishing-service:latest
+    image: projectlibertylabs/content-publishing-service:latest
     # For now, this is the only platform image published.
     platform: linux/amd64
     env_file:


### PR DESCRIPTION
# Problem

Rename is happening, so switching the docker hub username with this change.

Closes #322

# Solution

- Added new secrets to the GitHub org for the new `projectlibertylabs`
- Updated references to docker

## Steps to Verify:

1. Do a release
1. No more references to `amplicalabs` Docker